### PR TITLE
Refactor ReferralLinkService to accept Guid and use IUserRepository

### DIFF
--- a/CartonCaps.Api/Controllers/UserController.cs
+++ b/CartonCaps.Api/Controllers/UserController.cs
@@ -65,19 +65,12 @@ namespace CartonCaps.Api.Controllers
             //Mock for User.Identity.GetUserId()
             var userId = CartonCapsUser.MockLoggedInUserId;
 
-            var user = await userRepository.FetchUserById(userId, cancellationToken);
-            var deferredLink = await referralCodeService.FetchValidReferralLink(user, cancellationToken);
-
-            //Manually append the referral.
-            //The deferred link itself doesn't technically _need_ the referral code
-            //Query params feel like something that could change often so putting them in the most flexible layer
-            //makes sense to me.
-            //Can switch to include this step in FetchValidReferralLink for completeness
-            deferredLink = $"{deferredLink}?referral_code={user.ReferralCode}";
+            var referralCode = await userRepository.FetchUsersReferralCode(userId, cancellationToken);
+            var deferredLink = await referralCodeService.FetchValidReferralLink(userId, cancellationToken);
             
             return Ok(new ReferralCodeAndLinkResponse()
             {
-                ReferralCode = user.ReferralCode,
+                ReferralCode = referralCode,
 
                 DeferredLink = deferredLink
             });

--- a/CartonCaps.Core/Services/Referrals/IReferralLinkService.cs
+++ b/CartonCaps.Core/Services/Referrals/IReferralLinkService.cs
@@ -13,6 +13,6 @@ namespace CartonCaps.Core.Services.Referrals
         /// Ensures that a valid referral link can be retrieved
         /// Handles expiration and renewal
         /// </summary>
-        Task<string> FetchValidReferralLink(CartonCapsUser user, CancellationToken cancellationToken);
+        Task<string> FetchValidReferralLink(Guid userId, CancellationToken cancellationToken);
     }
 }

--- a/CartonCaps.Persistence/Repositories/IUserRepository.cs
+++ b/CartonCaps.Persistence/Repositories/IUserRepository.cs
@@ -14,5 +14,6 @@ namespace CartonCaps.Persistence.Repositories
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         Task<CartonCapsUser?> FetchUserById(Guid userId, CancellationToken cancellationToken);
+        Task<string?> FetchUsersReferralCode(Guid userId, CancellationToken cancellationToken);
     }
 }

--- a/CartonCaps.Persistence/Repositories/MockUserRepository.cs
+++ b/CartonCaps.Persistence/Repositories/MockUserRepository.cs
@@ -101,5 +101,10 @@ namespace CartonCaps.Persistence.Repositories
         {
             return userStore.Where(u => u.Id == userId).FirstOrDefault();
         }
+
+        public async Task<string?> FetchUsersReferralCode(Guid userId, CancellationToken cancellationToken)
+        {
+            return userStore.Where(u => u.Id == userId).FirstOrDefault()?.ReferralCode;
+        }
     }
 }

--- a/CartonCaps.ReferralAudit.Core/Services/UserReferralProcessor.cs
+++ b/CartonCaps.ReferralAudit.Core/Services/UserReferralProcessor.cs
@@ -42,6 +42,12 @@ namespace CartonCaps.ReferralAudit.Core.Services
         public async Task UpdateUsersReferrals(Guid userId, CancellationToken cancellationToken)
         {
             var user = await userRepository.FetchUserById(userId, cancellationToken);
+            if(user == null)
+            {
+                logger.LogError("User with ID {userId} not found. Skipping referral processing.", userId);
+                return;
+            }
+
             var userReferrals = await referralRepository.GetReferredUsersByReferringId(userId, cancellationToken);
 
             //Only proceed if we have referrals that are Pending

--- a/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/GivenUserMissing.cs
+++ b/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/GivenUserMissing.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using LeapingGorilla.Testing.Core.Attributes;
+using LeapingGorilla.Testing.Core.Composable;
+using LeapingGorilla.Testing.NUnit.Attributes;
+using NSubstitute.ReturnsExtensions;
+
+namespace CartonCaps.UnitTests.Services.Referrals.ReferralLinkServiceTests.FetchTests
+{
+    public class GivenUserMissing : WhenTestingFetchValidLink
+    {
+        protected override ComposedTest ComposeTest() => TestComposer
+            .Given(UserIdIsSet)
+            .And(RepositoryDoesNotReturnALink)
+            .And(UserRepositoryDoesNotReturnReferralCode)
+            .When(FetchValidLinkIsCalled)
+            .Then(ShouldReturnEmpty);
+
+        [Given]
+        public void UserRepositoryDoesNotReturnReferralCode()
+        {
+            UserRepository.FetchUsersReferralCode(UserId, CancellationToken)
+                .ReturnsNull();
+        }
+
+        [Then]
+        public void ShouldReturnEmpty()
+        {
+
+            Assert.That(Result, Is.Empty);
+        }
+    }
+}

--- a/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/GivenValidLinkExists.cs
+++ b/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/GivenValidLinkExists.cs
@@ -13,10 +13,10 @@ namespace CartonCaps.UnitTests.Services.Referrals.ReferralLinkServiceTests.Fetch
 {
     public class GivenValidLinkExists : WhenTestingFetchValidLink
     {
-        string ExpectedReferralUrl = "https://sample.com/app/link/abc123fg";
+        string ExpectedReferralUrl = "https://sample.com/app/link/abc123fg?referral_code=abc123fg";
 
         protected override ComposedTest ComposeTest() => TestComposer
-            .Given(UserIsSet)
+            .Given(UserIdIsSet)
             .And(RepositoryReturnsExistingReferralLink)
             .When(FetchValidLinkIsCalled)
             .Then(ShouldNotCreateReferral)
@@ -26,11 +26,11 @@ namespace CartonCaps.UnitTests.Services.Referrals.ReferralLinkServiceTests.Fetch
         [Given]
         public void RepositoryReturnsExistingReferralLink()
         {
-            ReferralLinkRepository.FetchUnexpiredReferralLinkByUserId(User.Id, CancellationToken)
+            ReferralLinkRepository.FetchUnexpiredReferralLinkByUserId(UserId, CancellationToken)
                 .Returns(new ReferralLink()
                 {
                     Id = Guid.NewGuid(),
-                    UserId = User.Id,
+                    UserId = UserId,
                     CreatedOn = DateTime.Now - TimeSpan.FromDays(5),
                     ExpiresOn = DateTime.Now + TimeSpan.FromDays(55),
                     Url = ExpectedReferralUrl

--- a/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/WhenTestingFetchValidLink.cs
+++ b/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/WhenTestingFetchValidLink.cs
@@ -5,32 +5,33 @@ using System.Text;
 using System.Threading.Tasks;
 using CartonCaps.Persistence.Models;
 using LeapingGorilla.Testing.Core.Attributes;
+using NSubstitute.ReturnsExtensions;
 
 namespace CartonCaps.UnitTests.Services.Referrals.ReferralLinkServiceTests.FetchTests
 {
     public abstract class WhenTestingFetchValidLink : WhenTestingReferralLinkService
     {
-        protected CartonCapsUser User;
+        protected Guid UserId;
 
         protected string Result;
 
         [Given]
-        public void UserIsSet()
+        public void UserIdIsSet()
         {
-            User = new CartonCapsUser()
-            {
-                Id = Guid.NewGuid(),
-                FirstName = "Sam",
-                LastName = "Pullman",
-                CreatedOn = DateTime.Now,
-                ReferralCode = "ABC123de",
-            };
+            UserId = Guid.NewGuid();
+        }
+
+        [Given]
+        public void RepositoryDoesNotReturnALink()
+        {
+            ReferralLinkRepository.FetchUnexpiredReferralLinkByUserId(UserId, CancellationToken)
+                .ReturnsNull();
         }
 
         [When]
         public async Task FetchValidLinkIsCalled()
         {
-            Result = await ReferralLinkService.FetchValidReferralLink(User, CancellationToken);
+            Result = await ReferralLinkService.FetchValidReferralLink(UserId, CancellationToken);
         }
     }
 }

--- a/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/WhenTestingReferralLinkService.cs
+++ b/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/WhenTestingReferralLinkService.cs
@@ -24,6 +24,9 @@ namespace CartonCaps.UnitTests.Services.Referrals.ReferralLinkServiceTests
         protected IDeferredLinkService DeferredLinkService;
 
         [Dependency]
+        protected IUserRepository UserRepository;
+
+        [Dependency]
         protected ILogger<ReferralLinkService> Logger;
 
         protected CancellationToken CancellationToken = default;


### PR DESCRIPTION
This update refactors `ReferralLinkService` so that it returns the deferred link and the referral code in the query parameter.

This further updates `UserController` to fetch referral code on its own. This is an intentional sacrifice of efficiency (+1 round trip to cache or database) for readabiltiy and simplicity in `ReferralLinkService`. 

A good next step would be to update `ReferralLinkService` to return both the deferred link and the referral code in either a response object or a tuple `(string link, string referralCode)`. This way we can resolve the extra round trip. Be wary though, this starts to violate Separation of Concerns.