### PR TITLE
Move ReferralCode fetching to ReferralLinkService

### DIFF
--- a/CartonCaps.Api/Controllers/UserController.cs
+++ b/CartonCaps.Api/Controllers/UserController.cs
@@ -65,8 +65,7 @@ namespace CartonCaps.Api.Controllers
             //Mock for User.Identity.GetUserId()
             var userId = CartonCapsUser.MockLoggedInUserId;
 
-            var referralCode = await userRepository.FetchUsersReferralCode(userId, cancellationToken);
-            var deferredLink = await referralCodeService.FetchValidReferralLink(userId, cancellationToken);
+            (var referralCode, var deferredLink) = await referralCodeService.FetchReferralCodeAndValidLink(userId, cancellationToken);
             
             return Ok(new ReferralCodeAndLinkResponse()
             {

--- a/CartonCaps.Core/Services/Referrals/IReferralLinkService.cs
+++ b/CartonCaps.Core/Services/Referrals/IReferralLinkService.cs
@@ -13,6 +13,6 @@ namespace CartonCaps.Core.Services.Referrals
         /// Ensures that a valid referral link can be retrieved
         /// Handles expiration and renewal
         /// </summary>
-        Task<string> FetchValidReferralLink(Guid userId, CancellationToken cancellationToken);
+        Task<(string referralCode, string deferredLink)> FetchReferralCodeAndValidLink(Guid userId, CancellationToken cancellationToken);
     }
 }

--- a/CartonCaps.IntegrationTests.Api/Controllers/UserControllerTests/ReferralCodeTests/GivenHappyPath.cs
+++ b/CartonCaps.IntegrationTests.Api/Controllers/UserControllerTests/ReferralCodeTests/GivenHappyPath.cs
@@ -46,8 +46,8 @@ namespace CartonCaps.IntegrationTests.Api.Controllers.UserControllerTests.Referr
         [Given]
         public void ReferralLinkServiceReturnsLink()
         {
-            ReferralLinkService.FetchValidReferralLink(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-                .Returns(ExpectedDeferredLink);
+            ReferralLinkService.FetchReferralCodeAndValidLink(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+                .Returns((ReferralCode, ExpectedDeferredLink));
         }
 
         [Then]

--- a/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/GivenNoValidLink.cs
+++ b/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/GivenNoValidLink.cs
@@ -25,7 +25,8 @@ namespace CartonCaps.UnitTests.Services.Referrals.ReferralLinkServiceTests.Fetch
             .And(DeferredLinkServiceCanCreateLink)
             .When(FetchValidLinkIsCalled)
             .Then(ShouldCallInsertLink)
-            .And(ShouldReturnExpectedLink);
+            .And(ShouldReturnExpectedReferralCode)
+            .And(ShouldReturnExpectedUrl);
 
         [Given]
         public void UserRepositoryFetchesReferralCode()
@@ -55,9 +56,15 @@ namespace CartonCaps.UnitTests.Services.Referrals.ReferralLinkServiceTests.Fetch
         }
 
         [Then]
-        public void ShouldReturnExpectedLink()
+        public void ShouldReturnExpectedUrl()
         {
-            Assert.That(Result, Is.EqualTo(ExpectedReferralUrl));
+            Assert.That(Result.deferredLink, Is.EqualTo(ExpectedReferralUrl));
+        }
+
+        [Then]
+        public void ShouldReturnExpectedReferralCode()
+        {
+            Assert.That(Result.referralCode, Is.EqualTo("abc123fg"));
         }
     }
 }

--- a/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/GivenUserMissing.cs
+++ b/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/GivenUserMissing.cs
@@ -30,7 +30,8 @@ namespace CartonCaps.UnitTests.Services.Referrals.ReferralLinkServiceTests.Fetch
         public void ShouldReturnEmpty()
         {
 
-            Assert.That(Result, Is.Empty);
+            Assert.That(Result.referralCode, Is.Empty);
+            Assert.That(Result.deferredLink, Is.Empty); 
         }
     }
 }

--- a/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/GivenValidLinkExists.cs
+++ b/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/GivenValidLinkExists.cs
@@ -21,7 +21,8 @@ namespace CartonCaps.UnitTests.Services.Referrals.ReferralLinkServiceTests.Fetch
             .When(FetchValidLinkIsCalled)
             .Then(ShouldNotCreateReferral)
             .And(ShouldNotInsertReferral)
-            .And(ShouldReturnExpectedUrl);
+            .And(ShouldReturnExpectedUrl)
+            .And(ShouldReturnExpectedReferralCode);
 
         [Given]
         public void RepositoryReturnsExistingReferralLink()
@@ -36,7 +37,7 @@ namespace CartonCaps.UnitTests.Services.Referrals.ReferralLinkServiceTests.Fetch
                     Url = ExpectedReferralUrl
                 });
         }
-        
+
         [Then]
         public void ShouldNotCreateReferral()
         {
@@ -56,7 +57,13 @@ namespace CartonCaps.UnitTests.Services.Referrals.ReferralLinkServiceTests.Fetch
         [Then]
         public void ShouldReturnExpectedUrl()
         {
-            Assert.That(Result, Is.EqualTo(ExpectedReferralUrl));
+            Assert.That(Result.deferredLink, Is.EqualTo(ExpectedReferralUrl));
+        }
+
+        [Then]
+        public void ShouldReturnExpectedReferralCode()
+        {
+            Assert.That(Result.referralCode, Is.EqualTo("abc123fg"));
         }
     }
 }

--- a/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/WhenTestingFetchValidLink.cs
+++ b/CartonCaps.UnitTests/Services/Referrals/ReferralLinkServiceTests/FetchTests/WhenTestingFetchValidLink.cs
@@ -13,7 +13,7 @@ namespace CartonCaps.UnitTests.Services.Referrals.ReferralLinkServiceTests.Fetch
     {
         protected Guid UserId;
 
-        protected string Result;
+        protected (string referralCode, string deferredLink) Result;
 
         [Given]
         public void UserIdIsSet()
@@ -31,7 +31,7 @@ namespace CartonCaps.UnitTests.Services.Referrals.ReferralLinkServiceTests.Fetch
         [When]
         public async Task FetchValidLinkIsCalled()
         {
-            Result = await ReferralLinkService.FetchValidReferralLink(UserId, CancellationToken);
+            Result = await ReferralLinkService.FetchReferralCodeAndValidLink(UserId, CancellationToken);
         }
     }
 }


### PR DESCRIPTION
This update returns the referral code along with the deferred referral link as part of a Tuple (string,string).

The advantage is we reduce the database round trips and we move the referral code to the service layer.
The disadvantage is it is now coupled with the deferred link. There is a natural relationship there but it might be a point for further refactoring as the service grows.

There is still a strong case to have the referral code be separate, especially if it is used elsewhere in the application without the deferred link. Sometimes it's best to just make a decision and execute on it. We can always refactor later if we design for maintainability.